### PR TITLE
a11y: fix keyboard nav with open on hover

### DIFF
--- a/src/blocks/mega-menu/render.php
+++ b/src/blocks/mega-menu/render.php
@@ -103,6 +103,7 @@ $allowed_html = array(
 		id="<?php echo esc_attr( $button_id ); ?>"
 		class="wp-block-ollie-mega-menu__toggle wp-block-navigation-item__content"
 		data-wp-on--click="actions.toggleMenuOnClick"
+		data-wp-on--focus="actions.openMenuOnFocus"
 		data-wp-on--mouseenter="actions.handleMouseEnter"
 		data-wp-on--mouseleave="actions.handleMouseLeave"
 		data-wp-bind--aria-expanded="state.isMenuOpen"

--- a/src/blocks/mega-menu/view.js
+++ b/src/blocks/mega-menu/view.js
@@ -460,10 +460,13 @@ const { state, actions } = store( 'ollie/mega-menu', {
 			// Safari won't send focus to the clicked element, so we need to manually place it: https://bugs.webkit.org/show_bug.cgi?id=22261
 			if ( window.document.activeElement !== ref ) ref.focus();
 
-			if ( state.menuOpenedBy.click || state.menuOpenedBy.focus ) {
+			// Only check click state for toggling (focus state is for keyboard nav)
+			if ( state.menuOpenedBy.click ) {
 				actions.closeMenu( 'click' );
 				actions.closeMenu( 'focus' );
 			} else {
+				// Close focus state and open by click
+				actions.closeMenu( 'focus' );
 				context.previousFocus = ref;
 				actions.openMenu( 'click' );
 			}
@@ -538,8 +541,17 @@ const { state, actions } = store( 'ollie/mega-menu', {
 		},
 		// ========== END HOVER FUNCTIONALITY ==========
 
+		openMenuOnFocus() {
+			// Only open if not already open
+			if ( state.isMenuOpen ) {
+				return;
+			}
+
+			// Open menu for keyboard accessibility
+			actions.openMenu( 'focus' );
+		},
 		handleMenuKeydown( event ) {
-			if ( state.menuOpenedBy.click ) {
+			if ( state.menuOpenedBy.click || state.menuOpenedBy.focus ) {
 				// If Escape close the menu.
 				if ( event?.key === 'Escape' ) {
 					actions.closeMenu( 'click' );


### PR DESCRIPTION
Addresses #2. Adds a directive to trigger the dropdown when focused and few JS adjustments.

Tested:
* Open on hover: off. Clicks work.
* Open on hover: off. Focus works.
* Open on hover: on, no link (button). Hover works.
* Open on hover: on, no link (button). Focus works.
* Open on hover: on, link (anchor). Hover works.
* Open on hover: on, link (anchor). Focus works.
* `Esc` handling works.