### PR TITLE
Fix hardcoded `/wp-admin/` paths for subdirectory WordPress installations

### DIFF
--- a/src/components/TemplateHelpText.js
+++ b/src/components/TemplateHelpText.js
@@ -12,6 +12,7 @@ import { createInterpolateElement } from '@wordpress/element';
  * @param {boolean} props.hasTemplates - Whether templates exist
  * @param {string} props.templateArea - Template area name
  * @param {string} props.siteUrl - Site URL for links
+ * @param {string} props.adminUrl - Admin URL for links
  * @param {Function} props.onCreateClick - Callback when create is clicked
  * @param {boolean} props.isCreating - Whether template is being created
  */
@@ -19,6 +20,7 @@ export default function TemplateHelpText( {
 	hasTemplates,
 	templateArea,
 	siteUrl,
+	adminUrl,
 	onCreateClick,
 	isCreating = false,
 } ) {
@@ -46,7 +48,7 @@ export default function TemplateHelpText( {
 				),
 				editor: (
 					<a
-						href={ `${ siteUrl }/wp-admin/site-editor.php?postType=wp_template_part&categoryId=${ templateArea }` }
+						href={ `${ adminUrl }site-editor.php?postType=wp_template_part&categoryId=${ templateArea }` }
 						target="_blank"
 						rel="noreferrer"
 						style={{ textDecoration: 'underline' }}

--- a/src/components/TemplateSelector.js
+++ b/src/components/TemplateSelector.js
@@ -58,7 +58,7 @@ export default function TemplateSelector( {
 
 	// Use multisite-aware URLs from localized data
 	const actualSiteUrl = window.menuDesignerData?.siteUrl || siteUrl || window.location.origin;
-	const adminUrl = window.menuDesignerData?.adminUrl || `${actualSiteUrl}/wp-admin`;
+	const adminUrl = window.menuDesignerData?.adminUrl || `${actualSiteUrl}/wp-admin/`;
 
 	const secureSiteUrl = getSecureUrl( actualSiteUrl );
 
@@ -118,6 +118,7 @@ export default function TemplateSelector( {
 						hasTemplates={ hasTemplates }
 						templateArea={ templateArea }
 						siteUrl={ secureSiteUrl }
+						adminUrl={ adminUrl }
 						onCreateClick={ createNewTemplate }
 						isCreating={ isCreating }
 					/>

--- a/src/hooks/useTemplateCreation.js
+++ b/src/hooks/useTemplateCreation.js
@@ -95,7 +95,7 @@ export default function useTemplateCreation( {
 				// Small delay to ensure the template is fully saved
 				setTimeout( () => {
 					// Navigate to the new template in the site editor
-					const editUrl = `${window.location.origin}/wp-admin/site-editor.php?postId=${encodeURIComponent( newTemplate.id )}&postType=wp_template_part&canvas=edit`;
+					const editUrl = `${window.menuDesignerData.adminUrl}site-editor.php?postId=${encodeURIComponent( newTemplate.id )}&postType=wp_template_part&canvas=edit`;
 					window.open( editUrl, '_blank' );
 				}, 500 );
 			} else {

--- a/src/mobile-menu/navigation-edit.js
+++ b/src/mobile-menu/navigation-edit.js
@@ -136,7 +136,7 @@ const withMobileMenuControls = createHigherOrderComponent( ( BlockEdit ) => {
 											),
 											editor: (
 												<a
-													href={ `${window.location.origin}/wp-admin/site-editor.php?postType=wp_template_part&categoryId=menu` }
+													href={ `${window.menuDesignerData.adminUrl}site-editor.php?postType=wp_template_part&categoryId=menu` }
 													target="_blank"
 													rel="noreferrer"
 													style={{ textDecoration: 'underline' }}


### PR DESCRIPTION
Replace hardcoded "`/wp-admin/`" URLs with `window.menuDesignerData.adminUrl` to support WordPress in subdirectories

Close #4